### PR TITLE
Rubo refrac

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'sinatra/base'
 require 'haml'
 require_relative 'check_number'
 
+# Rubocop: Top-level class documentation missing
 class Caya < Sinatra::Base
   include CheckNumber
 
@@ -17,9 +18,7 @@ class Caya < Sinatra::Base
   post '/single_check' do
     @period = params[:period]
     @number = params[:number]
-    if @period && !@number.empty?
-      @result = win?(@period, @number)
-    end
+    @result = win?(@period, @number) if @period && !@number.empty?
     haml :single_check
   end
 
@@ -29,19 +28,13 @@ class Caya < Sinatra::Base
 
   post '/multi_check' do
     @period = params[:period]
-    @numbers = params[:numbers].gsub(/\s+/, "").split(',')
-    if @period && @numbers != []
-      @results = all_win?(@period, @numbers)
-    end
-    if @results == {}
-      @result = 'I am sorry, you have no prize'
-    end
+    @numbers = params[:numbers].gsub(/\s+/, '').split(',')
+    @results = all_win?(@period, @numbers) if @period && @numbers != []
+    @result = 'I am sorry, you have no prize' if @results == {}
     haml :multi_check
   end
-
 
   not_found do
     'Oops you made a mistake ... right ?'
   end
-
 end

--- a/scrape.rb
+++ b/scrape.rb
@@ -6,6 +6,6 @@ data = []
 data = get_data
 
 # Serialize the data
-File.open("winning_numbers.yml", 'w') do |file|
+File.open('winning_numbers.yml', 'w') do |file|
   file.puts data.to_yaml
 end

--- a/scrape.rb
+++ b/scrape.rb
@@ -1,6 +1,6 @@
 require_relative 'winning_numbers_scrape'
 
-include Winning_Numbers_Scrape
+include WinningNumbersScrape
 
 data = []
 data = get_data

--- a/specs/scraper_spec.rb
+++ b/specs/scraper_spec.rb
@@ -9,10 +9,8 @@ require_relative '../winning_numbers_scrape'
 include Winning_Numbers_Scrape
 
 describe 'Getting the eTax winning numbers' do
-
   # 3. Be sure the periods[] is not empty and has 10 elements
   it 'Should give a non empty periods array' do
-    periods = []
     periods = get_period
     periods.wont_be_empty
     periods.length.must_equal 10
@@ -20,7 +18,6 @@ describe 'Getting the eTax winning numbers' do
 
   # 4. Be sure that etax_data[] is not empty
   it 'Should give a non empty etax_data array' do
-    data = []
     data = get_data
     data.wont_be_empty
   end

--- a/specs/scraper_spec.rb
+++ b/specs/scraper_spec.rb
@@ -12,7 +12,6 @@ describe 'Getting the eTax winning numbers' do
   # 3. Be sure the periods[] is not empty and has 10 elements
   it 'Should give a non empty periods array' do
     periods = get_period
-    puts periods
     periods.wont_be_empty
     periods.length.must_equal 10
   end
@@ -20,7 +19,6 @@ describe 'Getting the eTax winning numbers' do
   # 4. Be sure that etax_data[] is not empty
   it 'Should give a non empty etax_data array' do
     data = get_data
-    puts data
     data.wont_be_empty
   end
 end

--- a/specs/scraper_spec.rb
+++ b/specs/scraper_spec.rb
@@ -6,12 +6,13 @@
 require 'minitest/autorun'
 require_relative '../winning_numbers_scrape'
 
-include Winning_Numbers_Scrape
+include WinningNumbersScrape
 
 describe 'Getting the eTax winning numbers' do
   # 3. Be sure the periods[] is not empty and has 10 elements
   it 'Should give a non empty periods array' do
     periods = get_period
+    puts periods
     periods.wont_be_empty
     periods.length.must_equal 10
   end
@@ -19,6 +20,7 @@ describe 'Getting the eTax winning numbers' do
   # 4. Be sure that etax_data[] is not empty
   it 'Should give a non empty etax_data array' do
     data = get_data
+    puts data
     data.wont_be_empty
   end
 end

--- a/winning_numbers_scrape.rb
+++ b/winning_numbers_scrape.rb
@@ -2,8 +2,8 @@ require 'nokogiri'
 require 'open-uri'
 require 'yaml'
 
-module Winning_Numbers_Scrape
-
+# Rubocop: Top-level module documentation missing
+module WinningNumbersScrape
   # The urls and paths to data
   WEBSITE = 'http://www.etax.nat.gov.tw/etwmain/front'
   MAIN_PAGE = "#{WEBSITE}/ETW183W6?site=en"
@@ -27,57 +27,80 @@ module Winning_Numbers_Scrape
     periods
   end
 
-  def get_data
-    periods = []
-    periods = get_period
+  def data_from_link # for get_data
     # Scraping the data from each link (representing the period)
     numbers_table = []
     WINNING_TABLE_LINKS.each do |link|
-        url = "#{WEBSITE}/#{link}"
-        numberspage = Nokogiri::HTML(open(url))
-        numbers_table << numberspage.xpath(NUMBERS_TABLE_PATH)
+      url = "#{WEBSITE}/#{link}"
+      numberspage = Nokogiri::HTML(open(url))
+      numbers_table << numberspage.xpath(NUMBERS_TABLE_PATH)
     end
+    numbers_table
+  end
 
+  def winning_numbers_each_period(numbers_table) # for get_data
     # Getting the winning numbers for each period
     numbers = []
     regulations = []
     numbers_table.each do |num|
-      numbers << num.xpath("//td/span").text
-      regulations << num.xpath("//td")
+      numbers << num.xpath('//td/span').text
+      regulations << num.xpath('//td')
     end
+    [numbers, regulations]
+  end
 
+  def period_take_prize_regulation(regulations) # for get_data
     # Getting the period to take the prize
     first_regulation = []
-    from_until = []
     regulations.each do |regulate|
-      first_regulation << regulate[regulate.count - 1].xpath("//ol/li").text
+      first_regulation << regulate[regulate.count - 1].xpath('//ol/li').text
     end
+    first_regulation
+  end
+
+  def period_take_prize_until(first_regulation) # for get_data
+    # Getting the period to take the prize
+    from_until = []
     first_regulation.each do |regulation|
       from = /from \d+\/\d+\/\d+/.match(regulation)
       to = /to \d+\/\d+\/\d+/.match(regulation)
       from_until << "#{from}:#{to}".sub(/from/, '').sub(/to/, '')
     end
+    from_until
+  end
 
+  def assign_prize_groups(numbers, idx) # for make_etax
+    # The three first prizes are sent as an array for concision
+    a, b, c, d, e, f = *[0..7, 8..15, 16..23, 25..32, 34..41, 42..-1]
+    [numbers[idx][a], numbers[idx][b],
+     [numbers[idx][c], numbers[idx][d], numbers[idx][e]], # All first prizes
+     numbers[idx][f].split('、')]
+  end
+
+  def make_etax(numbers, from_until, periods, index) # for array_of_hashes
+    special_prize, grand_prize, first_prize,
+    additional_prizes = assign_prize_groups(numbers, index)
+    take_from_until = from_until[index].split(':')
+    Hash['Period', periods[index], 'Special Prize', special_prize,
+         'Grand Prize', grand_prize, 'First Prize', first_prize,
+         'Additional Prizes', additional_prizes, 'Take_Prize_From',
+         take_from_until[0], 'Take_Prize_Until', take_from_until[1]]
+  end
+
+  def array_of_hashes(numbers, from_until, periods, etax_data = [])
     # Creating a array of hashes
-    etax_data = []
-    numbers.each_with_index do |item, index|
-      special_prize = numbers[index][0..7]
-      grand_prize = numbers[index][8..15]
-      first_first_prize = numbers[index][16..23]
-      second_first_prize = numbers[index][25..32]
-      third_first_prize = numbers[index][34..41]
-      additional_prizes = numbers[index][42..-1].split("、")
-      take_from_until = from_until[index].split(":")
-      etax_data << [["Period", periods[index]],
-      ["Special Prize", special_prize],
-      ["Grand Prize", grand_prize],
-      ["First Prize", "#{first_first_prize}:#{second_first_prize}:#{third_first_prize}".split(":")],
-      ["Additional Prizes", additional_prizes],
-      ["Take_Prize_From", take_from_until[0]],
-      ["Take_Prize_Until", take_from_until[1]]].to_h
+    numbers.each_index do |index|
+      etax_data << make_etax(numbers, from_until, periods, index)
     end
-
     etax_data
   end
 
+  def get_data
+    periods = get_period
+    numbers_table = data_from_link
+    numbers, regulations = winning_numbers_each_period(numbers_table)
+    first_regulation = period_take_prize_regulation(regulations)
+    from_until = period_take_prize_until(first_regulation)
+    array_of_hashes(numbers, from_until, periods)
+  end
 end


### PR DESCRIPTION
Hello, here again
- Changed name of scraper module to CamelCase => Rubocop
- Minor refactoring of app.rb, scrape.rb & specs/scraper_spec.rb => Rubocop
- For winning_numbers_scrape.rb
  - Broke get_data method into several methods simply reusing the old code with minimal changes
  - Only major change to be found in creating etax_data
- Tested using: spec file; and scrape.rb which results in same output as original yml file

Rubocop complains about the names of get_data & get_period methods but given the discussion [here](https://stackoverflow.com/questions/26097084/why-does-rubocop-or-the-ruby-style-guide-prefer-not-to-use-get-or-set/26097971#26097971), I gather this Ruby style preference relates to getter and setter method in Classes.

Rubocop also complains about [some of the regex](https://i.imgur.com/SryKQRn.png) but not messing with it cos well, my regex ability, let's just say it's non-existent :(

Thanks,
James